### PR TITLE
Fix incorrect escaped provisioning output path

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/InstallProvisioningProfilesIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/InstallProvisioningProfilesIntegrationSpec.groovy
@@ -57,7 +57,7 @@ class InstallProvisioningProfilesIntegrationSpec extends IOSBuildTaskIntegration
             def mock = MobileProvisionMock.createMock({
                 it.uuid = id
             })
-            def installedProfile = new File(projectDir, "build/profiles/${id}.mobileprovision")
+            def installedProfile = new File(projectDir, "${installDir}/${id}.mobileprovision")
             new Tuple2<File, File>(mock, installedProfile)
         }
 
@@ -67,7 +67,7 @@ class InstallProvisioningProfilesIntegrationSpec extends IOSBuildTaskIntegration
         and:
         appendToSubjectTask("""
             provisioningProfiles.from(${wrapValueBasedOnType(files.collect { it.first }, "List<File>")})
-            outputDirectory = ${wrapValueBasedOnType(new File(projectDir, "build/profiles"), "File")}
+            outputDirectory = ${wrapValueBasedOnType(new File(projectDir, installDir), "File")}
         """.stripIndent())
 
         when:
@@ -82,6 +82,7 @@ class InstallProvisioningProfilesIntegrationSpec extends IOSBuildTaskIntegration
         }
 
         where:
+        installDir = "build/custom profiles/location"
         uuids = [UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()]
     }
 

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -235,7 +235,7 @@ class IOSBuildPlugin implements Plugin<Project> {
                 task.logFile.convention(project.layout.buildDirectory.file("logs/${task.name}.log"))
                 task.logToStdout.convention(project.provider {project.logger.isInfoEnabled()})
                 task.outputDirectory.convention(project.layout.dir(project.provider {
-                    new File("${System.getProperty("user.home")}/Library/MobileDevice/Provisioning\\ Profiles/")
+                    new File("${System.getProperty("user.home")}/Library/MobileDevice/Provisioning Profiles/")
                 }))
             }
         })


### PR DESCRIPTION
## Description

The default path to `~/Library/MobileDevice/Provisioning Profiles/` was incorrectly escaped. I fixed this and adjusted a test to used spaces in the output path.

## Changes

* ![FIX] incorrect escaped provisioning output path

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
