### PR TITLE
works around gradle 7 bug in collectOutputs task

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.BasePlugin
@@ -367,6 +368,10 @@ class IOSBuildPlugin implements Plugin<Project> {
         lockKeychain.configure({ it.mustRunAfter([xcodeArchive, xcodeExport]) })
 
         def collectOutputs = tasks.register("collectOutputs", Sync) {
+            // This is needed due to a bug on gradle 7 that sometimes does not recognize the default build strategy. Exclude is the default one.
+            // It happens when the same file is inserted in the copy command multiple times.
+            // See: https://github.com/gradle/gradle/issues/17236
+            it.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             it.from(xcodeExport, archiveDSYM)
             into(project.file("${project.buildDir}/outputs"))
         }


### PR DESCRIPTION
## Description
There is an issue in the Copy task in gradle 7. When duplicates happen, even if they are 'virtual' duplicates (ie. same file happening twice in the copy list), it complains about a lack of duplicate strategy and breaks. Gradle guys already said they wont fix this 
https://github.com/gradle/gradle/issues/17236#issuecomment-856806005
So we set an explicit duplicate strategy for the `collectOutputs` task here.

## Changes
* ![FIX] `collectOutputs` break when there are duplicates in Copy operation.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
