### PR TITLE
Removes activesupport pin & updates atlas-asdf to 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,7 @@ dependencies {
     api 'net.wooga.gradle:fastlane:[2,3['
     implementation "com.googlecode.plist:dd-plist:1.23"
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
-    //implementation 'net.wooga.gradle:asdf:[1,2['
-    implementation 'net.wooga.gradle:asdf:1.1.0'
+    implementation 'net.wooga.gradle:asdf:[1.1.0-rc.3,2['
 
     integrationTestImplementation'com.wooga.spock.extensions:spock-macos-keychain-extension:[1,2['
     testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation "com.googlecode.plist:dd-plist:1.23"
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
     //implementation 'net.wooga.gradle:asdf:[1,2['
-    implementation 'net.wooga.gradle:asdf:1.1.0-rc.2'
+    implementation 'net.wooga.gradle:asdf:1.1.0'
 
     integrationTestImplementation'com.wooga.spock.extensions:spock-macos-keychain-extension:[1,2['
     testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -776,6 +776,15 @@ class IOSBuildPluginIntegrationSpec extends IOSBuildIntegrationSpec {
         def command  = "$podsExec.absolutePath"
         assertProcess(command, "repo-art")
 
+        and: "'pod' version should be 1.14 or higher, and lesser than 2.x"
+        def versionStr = "${podsExec.absolutePath} --version".execute().with {
+            def (stdout, stderr) = [new StringBuilder(), new StringBuilder()]
+            it.waitForProcessOutput(stdout, stderr)
+            return stdout.toString()
+        }
+        def version = versionStr.split("\\.")
+        version[0].toInteger() == 1 && version[1].toInteger() >= 14
+
         where:
         stubs = ["pod"]
         stubsDir = "bin"

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -414,19 +414,12 @@ class IOSBuildPlugin implements Plugin<Project> {
         asdf.tool("ruby")
 
         def ruby = project.extensions.getByType(RubyPluginExtension)
-        ruby.enableGemfileGeneration()
-        // TODO: Remove once cocoapods is patched past 1.13.0
-        ruby.gem("activesupport", "7.0.8")
-        ruby.gem("cocoapods")
+        ruby.gem("cocoapods", "~> 1.14.3")
         ruby.gem("cocoapods-art")
         ruby.gem("cocoapods-pod-linkage")
 
-         def asdfGemInstallTask = project.tasks.named(RubyPlugin.RUBY_GEMFILE_TASK) {
-            dependsOn(RubyPlugin.BUNDLE_BIN_STUBS_TASK)
-        }
-
         project.tasks.withType(PodInstallTask).configureEach {
-            it.dependsOn(asdfGemInstallTask)
+            it.dependsOn(RubyPlugin.RUBY_BIN_STUBS_TASK)
             it.executableDirectory.set(ruby.stubsDir)
         }
     }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -23,10 +23,7 @@ import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.file.Directory
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.api.internal.provider.Providers
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.BasePlugin

--- a/src/test/groovy/com/wooga/security/SecurityHelper.groovy
+++ b/src/test/groovy/com/wooga/security/SecurityHelper.groovy
@@ -154,7 +154,7 @@ class SecurityHelper {
              '-keyout', caKey.path,
              '-passout', "pass:${passphrase}",
              '-out', caReq.path,
-             '-config', cnf.path
+             '-config', cnf.path,
         ].execute().waitFor() == 0) {
             if (['openssl', 'ca', '-create_serial',
                  '-out', caCert, '-batch',
@@ -164,7 +164,7 @@ class SecurityHelper {
                  'v3_ca',
                  '-passin', "pass:${passphrase}",
                  '-config', cnf.path,
-                 '-infiles', caReq.path
+                 '-infiles', caReq.path,
             ].execute().waitFor() == 0) {
                 return new CA(caKey, caCert, cnf, "123456")
             }
@@ -250,7 +250,7 @@ class SecurityHelper {
                     '-inkey', key.path,
                     '-out', p12.path,
                     '-name', options['privateKeyName'],
-                    '-passout', "pass:${password}"
+                    '-passout', "pass:${password}", '-legacy'
         ]
         if (args.execute().waitFor() == 0) {
             return p12


### PR DESCRIPTION
## Description
Cocoapods fixed the bug in their 1.13 version, so we don't need to pin activesupport anymore. Additionally we apply the changes done between atlas-asdf 1.1.0-rc.1 to 1.0.0-final verisons here.

## Changes
* ![UPDATE] atlas-asdf to 1.1.0
* ![UPDATE] cocoapods version installed by atlas-asdf to [1.14.3, 2)
* ![UPDATE] not pinning activesupport anymore when installing cocoapods.
  

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
