### PR TITLE
Add cocoapods version property [ATLAS-1640]

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -580,6 +580,16 @@ class IOSBuildPluginIntegrationSpec extends IOSBuildIntegrationSpec {
         "cocoapods.executableDirectory"     | setter                             | osPath("/path/to/project8")                                                                | "Provider<Directory>"           | PropertyLocation.script
         "cocoapods.executableDirectory"     | _                                  | null                                                                                       | _                               | PropertyLocation.none
 
+        "cocoapods.version"                 | _                                  | "1.1.1"                                                                                    | _                               | PropertyLocation.environment
+        "cocoapods.version"                 | _                                  | "1.1.2"                                                                                    | _                               | PropertyLocation.property
+        "cocoapods.version"                 | assignment                         | "1.1.3"                                                                                    | "String"                        | PropertyLocation.script
+        "cocoapods.version"                 | assignment                         | "1.1.4"                                                                                    | "Provider<String>"              | PropertyLocation.script
+        "cocoapods.version"                 | providerSet                        | "1.1.5"                                                                                    | "String"                        | PropertyLocation.script
+        "cocoapods.version"                 | providerSet                        | "1.1.6"                                                                                    | "Provider<String>"              | PropertyLocation.script
+        "cocoapods.version"                 | setter                             | "1.1.7"                                                                                    | "String"                        | PropertyLocation.script
+        "cocoapods.version"                 | setter                             | "1.1.8"                                                                                    | "Provider<String>"              | PropertyLocation.script
+        "cocoapods.version"                 | _                                  | "~> 1.14.3"                                                                                 | _                               | PropertyLocation.none
+
         "projectPath"                       | _                                  | projectFile("Unity-iPhone.xcodeproj")                                                      | "File"                          | PropertyLocation.none
         "xcodeProjectFileName"              | _                                  | "Unity-iPhone.xcodeproj"                                                                   | "String"                        | PropertyLocation.none
         "xcodeWorkspaceFileName"            | _                                  | "Unity-iPhone.xcworkspace"                                                                 | "String"                        | PropertyLocation.none
@@ -587,10 +597,10 @@ class IOSBuildPluginIntegrationSpec extends IOSBuildIntegrationSpec {
 
 
         set = new PropertySetterWriter(extensionName, property)
-            .serialize(wrapValueFallback)
-            .set(rawValue, type)
-            .to(location)
-            .use(invocation)
+                .serialize(wrapValueFallback)
+                .set(rawValue, type)
+                .to(location)
+                .use(invocation)
 
         get = new PropertyGetterTaskWriter(set)
     }
@@ -773,7 +783,7 @@ class IOSBuildPluginIntegrationSpec extends IOSBuildIntegrationSpec {
 
         and: "'pod' executable should have 'repo-art' subcommand"
         def podsExec = Paths.get(projectDir.absolutePath, stubsDir, "pod").toFile()
-        def command  = "$podsExec.absolutePath"
+        def command = "$podsExec.absolutePath"
         assertProcess(command, "repo-art")
 
         and: "'pod' version should be 1.14 or higher, and lesser than 2.x"

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginConventions.groovy
@@ -29,6 +29,10 @@ class IOSBuildPluginConventions {
             "iosBuild.cocoapods.executableDirectory",
             null)
 
+    static final PropertyLookup cocoaPodsVersion = new PropertyLookup("IOS_BUILD_COCOAPODS_VERSION",
+            ["iosBuild.cocoapods.version"],
+            "~> 1.14.3")
+
     static final PropertyLookup xcodeProjectDirectory = new PropertyLookup(
             "IOS_BUILD_XCODE_PROJECT_DIRECTORY",
             "iosBuild.xcodeProjectDirectory",
@@ -121,5 +125,6 @@ class IOSBuildPluginConventions {
     static final PropertyLookup asdfVersion = new PropertyLookup("IOS_BUILD_ASDF_VERSION",
             ["iosBuild.asdf.version"],
         "0.13.1")
+
 }
 

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.util.ConfigureUtil
 import wooga.gradle.xcodebuild.config.ExportOptions
 
@@ -383,15 +384,30 @@ trait IOSBuildPluginExtension extends BaseSpec {
         it.dir(xcodeProjectFileName)
     })
 
-    protected static class CocoaPods implements ExecSpec {}
+    protected static class CocoaPods implements ExecSpec {
+        private final Property<String> version = objects.property(String)
 
-    ExecSpec cocoapods = objects.newInstance(CocoaPods)
+        Property<String> getVersion() {
+            return version
+        }
+
+        void setVersion(String version) {
+            this.version.set(version)
+        }
+
+        void setVersion(Provider<String> version) {
+            this.version.set(version)
+        }
+    }
+
+    CocoaPods cocoapods = objects.newInstance(CocoaPods)
 
     void cocoapods(Action<ExecSpec> action) {
         action.execute(cocoapods)
     }
 
-    void cocoapods(@ClosureParams(value = FromString.class, options = ["com.wooga.gradle.io.ExecSpec"])Closure configure) {
+    void cocoapods(@ClosureParams(value = FromString.class,
+            options = ["wooga.gradle.build.unity.ios.IOSBuildPluginExtension.CocoaPods"]) Closure configure) {
         cocoapods(configureUsing(configure))
     }
 }


### PR DESCRIPTION
## Description
Current way of changing cocoapods version requires thinkering with `net.wooga.asdf` which is not directly applied and it may be confusing. As this is a game-team facing plugin it should do its best to not expose too much of the underlying wiring. 
So we add a new property `iosBuild.cocoaPods.version` to set a version to the cocoapods plugin without having to set it directly into the underlying `asdf-ruby` plugin.  

## Changes
* ![ADD] `iosBuild.cocoaPods.version` property.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
