### PR TITLE
Change cocoapods install command from gem install to bundle install

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -787,7 +787,9 @@ class IOSBuildPluginIntegrationSpec extends IOSBuildIntegrationSpec {
         assertProcess(command, "repo-art")
 
         and: "'pod' version should be 1.14 or higher, and lesser than 2.x"
-        def versionStr = "${podsExec.absolutePath} --version".execute().with {
+
+        def versionCmd = new ProcessBuilder([podsExec.absolutePath, "--version"]).directory(projectDir)
+        def versionStr = versionCmd.start().with {
             def (stdout, stderr) = [new StringBuilder(), new StringBuilder()]
             it.waitForProcessOutput(stdout, stderr)
             return stdout.toString()

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -409,12 +409,12 @@ class IOSBuildPlugin implements Plugin<Project> {
 
         def asdf = project.extensions.getByType(AsdfPluginExtension)
         asdf.version.convention(IOSBuildPluginConventions.asdfVersion.getStringValueProvider(project))
-        asdf.tool("ruby")
 
         def ruby = project.extensions.getByType(RubyPluginExtension)
-        ruby.gem(new ToolVersionInfo("cocoapods", iosBuild.cocoapods.version))
-        ruby.gem("cocoapods-art")
-        ruby.gem("cocoapods-pod-linkage")
+        ruby.tool(new ToolVersionInfo("cocoapods", iosBuild.cocoapods.version)) {
+            it.gem("cocoapods-art", [])
+            it.gem("cocoapods-pod-linkage", [])
+        }
 
         project.tasks.withType(PodInstallTask).configureEach {
             it.dependsOn(RubyPlugin.RUBY_BIN_STUBS_TASK)

--- a/src/test/groovy/com/wooga/security/SecurityHelper.groovy
+++ b/src/test/groovy/com/wooga/security/SecurityHelper.groovy
@@ -250,7 +250,7 @@ class SecurityHelper {
                     '-inkey', key.path,
                     '-out', p12.path,
                     '-name', options['privateKeyName'],
-                    '-passout', "pass:${password}"
+                    '-passout', "pass:${password}", '-legacy'
         ]
         def sout = new StringBuilder(), serr = new StringBuilder()
         def proc = args.execute()


### PR DESCRIPTION
## Description
Cocoapods and its extras now install with Gemfile+`bundle install`, instead of `gem install`. This helps it to be more stable and predictable in regards of the versions being used. 

## Changes
* ![CHANGE] cocoapods install now uses `asdfRuby.tool` instead of `asdfRuby.gem`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
