### PR TITLE
Openssl pkcs12 run on test now tries with and without -legacy

### DIFF
--- a/src/test/groovy/com/wooga/security/SecurityHelper.groovy
+++ b/src/test/groovy/com/wooga/security/SecurityHelper.groovy
@@ -250,18 +250,30 @@ class SecurityHelper {
                     '-inkey', key.path,
                     '-out', p12.path,
                     '-name', options['privateKeyName'],
-                    '-passout', "pass:${password}"
+                    '-passout', "pass:${password}", '-legacy'
         ]
         def sout = new StringBuilder(), serr = new StringBuilder()
+
+        //run with -legacy
         def proc = args.execute()
         proc.consumeProcessOutput(sout, serr)
         if (proc.waitFor() == 0) {
+            // if success, great, we have our result
             return p12
-        } else {
-            println(sout)
-            println("====stderr====")
-            println(serr)
         }
+
+        //if -legacy fails, run without -legacy
+        args = args.remove('-legacy')
+        proc = args.execute()
+        proc.consumeProcessOutput(sout, serr)
+        if(proc.waitFor() == 0) {
+            //success without -legacy, we have our result
+            return p12
+        }
+        //on error, print process output to help with debug
+        println(sout)
+        println("====stderr====")
+        println(serr)
         return null
     }
 


### PR DESCRIPTION
## Description
There seems to be a complete lack of standard on which openssl implementations uses -legacy to generate apple compatible pkcs12 keys, and the ones that don't. This results in the openssl-dependent tests running well in some machines and not in others. Ideally we would standardize openssl in all machines, but they all seems to have the same version/implementation (libressl) already. So to work around this, we first try with -legacy, and if the process fails, we try without it. 

## Changes
* ![FIX] flaky openssl-related tests.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
