### PR TITLE
Update net.wooga.asdf to 2.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ plugins {
 }
 
 group 'net.wooga.gradle'
+java.sourceCompatibility = JavaVersion.VERSION_11
 
 pluginBundle {
     website = 'https://wooga.github.io/atlas-build-unity-ios/'
@@ -55,7 +56,7 @@ dependencies {
     api 'net.wooga.gradle:fastlane:[2,3['
     implementation "com.googlecode.plist:dd-plist:1.23"
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
-    implementation 'net.wooga.gradle:asdf:[1.1.0-rc.3,2['
+    implementation 'net.wooga.gradle:asdf:[2,3['
 
     integrationTestImplementation'com.wooga.spock.extensions:spock-macos-keychain-extension:[1,2['
     testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -110,7 +110,7 @@ class IOSBuildPluginIntegrationSpec extends IOSBuildIntegrationSpec {
     }
 
     def cleanup() {
-        keychainLookupList.reset()
+        keychainLookupList?.reset()
     }
 
     @Requires({ os.macOs && env['ATLAS_BUILD_UNITY_IOS_EXECUTE_KEYCHAIN_SPEC'] == 'YES' })


### PR DESCRIPTION
## Description
Due to security issues in transient dependencies (jgit) we have to update the `net.wooga.gradle:asdf` dependency to the 2.x version range. As this version requires java 11 as minimum source level, we'll have to set this here as well, making this PR a breaking change. 

## Changes
* ![UPDATE]  `net.wooga.gradle:asdf` to `[2,3)`
* ![CHANGE] minimum supported java sdk level is now 11.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
